### PR TITLE
multiple popups and components in the same screen

### DIFF
--- a/src/popup.component.ts
+++ b/src/popup.component.ts
@@ -29,6 +29,8 @@ import { Ng2OverlayManager, Ng2Overlay, Ng2OverlayDirective } from 'ng2-overlay'
       border-radius: 5px;
       width: 600px;
       display: none;
+      position: absolute;
+      z-index: 100;
     }
     .popup-container.opened { 
       display: block;


### PR DESCRIPTION
multiple popups in multiple components in the same screen creates a bug.

This commit fix this problem with a css change

Issue:
https://github.com/ng2-ui/popup/issues/17